### PR TITLE
Add bass clef display for bass clef instruments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,8 @@ Core JavaScript file containing all pitch detection logic:
 | `centsOffFromPitch(frequency, note)` | 212 | Calculates detuning in cents |
 | `setup()` / `draw()` | 335/342 | p5.js canvas initialization and rendering |
 | `drawStaff()` / `drawNote()` | 371/380 | Musical staff visualization helpers |
-| `drawTrebleClef(x, y)` | 402 | Draws treble clef symbol at position |
+| `drawTrebleClef(x, y)` | 408 | Draws treble clef symbol at position |
+| `drawBassClef(x, y)` | 452 | Draws bass clef symbol at position |
 
 ## Core Algorithm: ACF2+ (Auto-Correlation)
 
@@ -131,8 +132,13 @@ If the instrument reads treble clef, add it to the `trebleClefInstruments` array
 var trebleClefInstruments = ["flute", "clarinet", "alto sax", "trumpet", "horn", "new_instrument"];
 ```
 
+If the instrument reads bass clef, add it to the `bassClefInstruments` array:
+```javascript
+var bassClefInstruments = ["trombone", "euphonium", "new_instrument"];
+```
+
 **Treble clef instruments:** flute, clarinet, alto sax, trumpet, horn
-**Bass clef instruments:** trombone, euphonium (no clef displayed currently)
+**Bass clef instruments:** trombone, euphonium
 
 ### Adjusting Detection Sensitivity
 In `js/pitchdetect.js`:
@@ -148,8 +154,7 @@ In `js/pitchdetect.js`:
 1. **Monophonic only** - Works best with single-note sources (whistling, flute, guitar tuning)
 2. **Strong harmonics** - May throw off detection accuracy
 3. **No polyphonic detection** - Cannot detect chords
-4. **Instrument selector** - Displays treble clef for treble instruments, but no transposition implemented yet
-5. **Bass clef** - Not yet implemented for bass clef instruments (trombone, euphonium)
+4. **Instrument selector** - Displays appropriate clef for instruments, but no transposition implemented yet
 
 ## Code Style Conventions
 

--- a/js/pitchdetect.js
+++ b/js/pitchdetect.js
@@ -353,6 +353,10 @@ function draw() {
 		// Draw treble clef on the G line (y=250, which is 100 + 150)
 		drawTrebleClef(50, 250);
 		noteOffset = 50; // Shift notes right to make room for clef
+	} else if (bassClefInstruments.includes(selectedInstrument)) {
+		// Draw bass clef on the F line (y=150, which is 100 + 50)
+		drawBassClef(50, 150);
+		noteOffset = 50; // Shift notes right to make room for clef
 	}
 
 	let note = noteName[noteStringArray[0]];
@@ -399,6 +403,9 @@ function drawFlat(x,y){
 // Treble clef instruments
 var trebleClefInstruments = ["flute", "clarinet", "alto sax", "trumpet", "horn"];
 
+// Bass clef instruments
+var bassClefInstruments = ["trombone", "euphonium"];
+
 function drawTrebleClef(x, y) {
 	// Draw treble clef (G-clef) at position x, y where y is the G line (second from bottom)
 	// The clef is drawn relative to the G line at y=250 when staff starts at y=100
@@ -437,6 +444,42 @@ function drawTrebleClef(x, y) {
 	// Small dot at the bottom of the tail
 	fill(0);
 	ellipse(x + 15, y + 100, 12, 12);
+	noFill();
+
+	pop();
+}
+
+function drawBassClef(x, y) {
+	// Draw bass clef (F-clef) at position x, y where y is the F line (4th line from bottom)
+	// The clef is drawn relative to the F line at y=150 when staff starts at y=100
+	push();
+	strokeWeight(4);
+	noFill();
+
+	// Main curved body of bass clef
+	beginShape();
+	curveVertex(x + 5, y - 5);
+	curveVertex(x + 5, y - 5);
+	curveVertex(x + 15, y - 15);
+	curveVertex(x + 20, y - 35);
+	curveVertex(x + 15, y - 55);
+	curveVertex(x, y - 65);
+	curveVertex(x - 15, y - 55);
+	curveVertex(x - 20, y - 30);
+	curveVertex(x - 15, y);
+	curveVertex(x, y + 30);
+	curveVertex(x + 20, y + 60);
+	curveVertex(x + 45, y + 85);
+	curveVertex(x + 45, y + 85);
+	endShape();
+
+	// Two dots next to the F line
+	fill(0);
+	ellipse(x + 30, y - 25, 10, 10); // Dot above F line
+	ellipse(x + 30, y + 25, 10, 10); // Dot below F line
+
+	// Starting dot on F line
+	ellipse(x + 5, y, 12, 12);
 	noFill();
 
 	pop();


### PR DESCRIPTION
- Add bassClefInstruments array (trombone, euphonium)
- Add drawBassClef() function using p5.js curves to draw F-clef
- Update draw() to check for bass clef instruments and display clef
- Bass clef includes curved body and two dots beside F line
- Update CLAUDE.md documentation with new feature

https://claude.ai/code/session_01WR8fwwhERLKiuS8jbPSpgM