### PR TITLE
Replace p5.js with VexFlow for professional music notation

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,12 @@
 				box-shadow: 0 2px 10px rgba(0,0,0,0.1);
 			}
 
-			.p5Canvas {
+			#vexflow-output {
+				min-width: 320px;
+				min-height: 180px;
+			}
+
+			#vexflow-output svg {
 				display: block;
 			}
 
@@ -271,7 +276,7 @@
 				</div>
 
 				<div class="canvas-container">
-					<!-- p5.js canvas will be inserted here -->
+					<div id="vexflow-output"></div>
 				</div>
 			</div>
 		</div>
@@ -280,6 +285,6 @@
 			<img src="img/forkme.png" alt="Fork me on GitHub">
 		</a>
 
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/vexflow@4.2.6/build/cjs/vexflow.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
- Remove p5.js library and all custom drawing functions
- Add VexFlow 4.2.6 library for music notation rendering
- Create VexFlow renderer targeting #vexflow-output div
- Add renderNotation() function to display staff, clef, and note
- Only re-render when note/octave/instrument actually changes
- Support treble and bass clef based on selected instrument
- Display whole notes with proper accidentals (sharps/flats)
- Add instrument change listener to update clef immediately
- Professional SVG-based notation output

https://claude.ai/code/session_01WR8fwwhERLKiuS8jbPSpgM