### PR TITLE
Show enharmonic spellings in note letter display

### DIFF
--- a/js/pitchdetect.js
+++ b/js/pitchdetect.js
@@ -367,7 +367,14 @@ function updatePitch( time ) {
 	 	notetoDraw = noteStrings[writtenNote % 12];
 	 	octavetoDraw = Math.floor(writtenNote / 12) - 1; // MIDI note to octave
 
-		noteElem.innerHTML = notetoDraw;
+		// Display note name with enharmonic equivalent if applicable
+		var enharmonic = getEnharmonic(notetoDraw, octavetoDraw);
+		if (enharmonic) {
+			// Show both sharp and flat spellings
+			noteElem.innerHTML = enharmonic.sharp.name + " / " + enharmonic.flat.name;
+		} else {
+			noteElem.innerHTML = notetoDraw;
+		}
 
 		// Update VexFlow notation display
 		updateNotation();


### PR DESCRIPTION
For notes with accidentals, display both sharp and flat versions (e.g., "C# / Db") in the note name area above the staff.

https://claude.ai/code/session_01WR8fwwhERLKiuS8jbPSpgM