### PR TITLE
Auto-start pitch detection on instrument selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,24 +49,25 @@
 				flex-shrink: 0;
 			}
 
-			#startStopButton {
+			#stopButton {
 				padding: 12px 32px;
 				font-size: 16px;
 				font-family: 'Alike', sans-serif;
-				background-color: #4CAF50;
+				background-color: #e74c3c;
 				color: white;
 				border: none;
 				border-radius: 6px;
 				cursor: pointer;
 				transition: background-color 0.2s;
+				display: none;
 			}
 
-			#startStopButton:hover {
-				background-color: #45a049;
+			#stopButton:hover {
+				background-color: #c0392b;
 			}
 
-			#startStopButton:active {
-				background-color: #3d8b40;
+			#stopButton:active {
+				background-color: #a93226;
 			}
 
 			#instrument {
@@ -226,7 +227,7 @@
 					margin-bottom: 10px;
 				}
 
-				#startStopButton,
+				#stopButton,
 				#instrument {
 					width: 100%;
 					max-width: 280px;
@@ -260,9 +261,10 @@
 			<h1>Pitch Detector</h1>
 
 			<div class="controls">
-				<button id="startStopButton" onclick="togglePitchDetect();">Start</button>
 				<select name="Instrument" id="instrument">
-					<option value="">--Pick your instrument--</option>
+					<option value="">Select an instrument to begin</option>
+					<option value="treble clef">Treble Clef</option>
+					<option value="bass clef">Bass Clef</option>
 					<option value="flute">Flute</option>
 					<option value="oboe">Oboe</option>
 					<option value="clarinet">Clarinet</option>
@@ -278,6 +280,7 @@
 					<option value="tuba">Tuba</option>
 					<option value="glockenspiel">Glockenspiel</option>
 				</select>
+				<button id="stopButton" onclick="stopPitchDetect();">Stop</button>
 			</div>
 
 			<div class="main-display">

--- a/js/pitchdetect.js
+++ b/js/pitchdetect.js
@@ -121,9 +121,9 @@ function startPitchDetect() {
 	    analyser.fftSize = 2048;
 	    mediaStreamSource.connect( analyser );
 
-	    // Update state and button
+	    // Update state and show stop button
 	    isPlaying = true;
-	    document.getElementById("startStopButton").innerText = "Stop";
+	    document.getElementById("stopButton").style.display = "inline-block";
 
 	    updatePitch();
     }).catch((err) => {
@@ -159,8 +159,9 @@ function stopPitchDetect() {
     mediaStreamSource = null;
     isPlaying = false;
 
-    // Update button text
-    document.getElementById("startStopButton").innerText = "Start";
+    // Hide stop button and reset instrument selector
+    document.getElementById("stopButton").style.display = "none";
+    document.getElementById("instrument").selectedIndex = 0;
 
     // Reset display
     detectorElem.className = "vague";
@@ -168,6 +169,10 @@ function stopPitchDetect() {
     noteElem.innerText = "-";
     detuneElem.className = "";
     detuneAmount.innerText = "--";
+
+    // Reset notation display
+    lastRenderedInstrument = null;
+    renderNotation(null, null, "");
 }
 
 function error() {
@@ -400,18 +405,20 @@ function updatePitch( time ) {
 
 // Treble clef instruments
 var trebleClefInstruments = [
-	"flute", "oboe", "clarinet", "bass clarinet",
+	"treble clef", "flute", "oboe", "clarinet", "bass clarinet",
 	"alto sax", "tenor sax", "bari sax",
 	"trumpet", "horn", "glockenspiel"
 ];
 
 // Bass clef instruments
-var bassClefInstruments = ["bassoon", "trombone", "euphonium", "tuba"];
+var bassClefInstruments = ["bass clef", "bassoon", "trombone", "euphonium", "tuba"];
 
 // Transposition map: semitones to add to concert pitch to get written pitch
 // Positive = written pitch is higher than concert pitch
 var transpositionMap = {
 	"": 0,                // No instrument selected - concert pitch
+	"treble clef": 0,     // Generic treble clef - concert pitch
+	"bass clef": 0,       // Generic bass clef - concert pitch
 	"flute": 0,           // C instrument - concert pitch
 	"oboe": 0,            // C instrument - concert pitch
 	"clarinet": 2,        // Bb instrument - up major 2nd
@@ -611,9 +618,17 @@ document.addEventListener("DOMContentLoaded", function() {
 	var instrumentSelect = document.getElementById("instrument");
 	if (instrumentSelect) {
 		instrumentSelect.addEventListener("change", function() {
-			// Force re-render with new clef
-			lastRenderedInstrument = null;
-			updateNotation();
+			// If an instrument is selected, auto-start pitch detection
+			if (instrumentSelect.value !== "") {
+				// Force re-render with new clef
+				lastRenderedInstrument = null;
+				updateNotation();
+
+				// Start pitch detection if not already playing
+				if (!isPlaying) {
+					startPitchDetect();
+				}
+			}
 		});
 	}
 


### PR DESCRIPTION
- Remove start button, add stop button that appears when detecting
- Add "Select an instrument to begin" as default dropdown option
- Add generic "Treble Clef" and "Bass Clef" instruments
- Auto-start pitch detection when user selects an instrument
- Clicking stop returns app to initial state with instrument reset

https://claude.ai/code/session_01WR8fwwhERLKiuS8jbPSpgM