### PR TITLE
Add visual tuning feedback with color gradient on note display

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,9 @@
 				line-height: 1.1;
 				display: block;
 				margin: 10px 0;
+				padding: 10px 20px;
+				border-radius: 8px;
+				transition: background-color 0.2s ease;
 			}
 
 			#detune {

--- a/js/pitchdetect.js
+++ b/js/pitchdetect.js
@@ -168,6 +168,7 @@ function stopPitchDetect() {
     detectorElem.className = "vague";
     pitchElem.innerText = "--";
     noteElem.innerText = "-";
+    noteElem.style.backgroundColor = "transparent";
     detuneElem.className = "";
     detuneAmount.innerText = "--";
 
@@ -455,6 +456,7 @@ function updatePitch( time ) {
  		detectorElem.className = "vague";
 	 	pitchElem.innerText = "--";
 		noteElem.innerText = "-";
+		noteElem.style.backgroundColor = "transparent";
 		detuneElem.className = "";
 		detuneAmount.innerText = "--";
  	} else {
@@ -490,6 +492,18 @@ function updatePitch( time ) {
 
 		// Detuning is still based on concert pitch (how in-tune they actually are)
 		var detune = centsOffFromPitch(pitch, concertNote);
+
+		// Calculate background color intensity based on how out of tune
+		// 0 cents = transparent, 50+ cents = fully opaque
+		var absDetune = Math.abs(detune);
+		var maxDetune = 50; // cents at which we reach maximum darkness
+		var intensity = Math.min(absDetune / maxDetune, 1.0);
+
+		// Use a darker color with increasing opacity as note gets more out of tune
+		// RGB(200, 100, 100) gives a muted red/brown color
+		var alpha = intensity * 0.5; // Max opacity of 0.5 to keep text readable
+		noteElem.style.backgroundColor = "rgba(200, 100, 100, " + alpha + ")";
+
 		if (detune == 0) {
 			detuneElem.className = "";
 			detuneAmount.innerHTML = "--";


### PR DESCRIPTION
Implements a dynamic background color on the note name that darkens as the pitch becomes more out of tune. The color intensity is calculated based on cents off from the target pitch, providing immediate visual feedback for tuning accuracy.

- Note background fades from transparent (in tune) to darker red-brown (out of tune)
- Color intensity scales linearly from 0 to 50 cents off
- Smooth CSS transitions for visual polish
- Background resets to transparent when no valid pitch detected

https://claude.ai/code/session_015EsWUTiQfKVuGLRjm2sggi