### PR TITLE
fix initialization 

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,18 @@
 				background-color: #a93226;
 			}
 
+			#stopButton.start-mode {
+				background-color: #4CAF50;
+			}
+
+			#stopButton.start-mode:hover {
+				background-color: #388E3C;
+			}
+
+			#stopButton.start-mode:active {
+				background-color: #2E7D32;
+			}
+
 			#instrument {
 				padding: 12px 16px;
 				font-size: 16px;
@@ -506,7 +518,7 @@
 					<option value="tuba">Tuba</option>
 					<option value="glockenspiel">Glockenspiel</option>
 				</select>
-				<button id="stopButton" onclick="stopPitchDetect();">Stop</button>
+				<button id="stopButton" onclick="togglePitchDetect();">Start</button>
 			</div>
 
 			<div class="main-display">


### PR DESCRIPTION
Fix: show Start button when instrument is restored from localStorage

When the page is revisited and the previously selected instrument is
loaded from memory, the detector had no way to be initiated: the Stop
button was hidden (nothing was playing) and the instrument dropdown
already showed the saved value so changing it to the same value never
fired a change event.

Changes:
- Convert the hidden Stop button into a persistent Start/Stop toggle
  button (green "Start" / red "Stop") that is visible whenever an
  instrument is selected.
- updateToggleButton() helper keeps the button label and colour in sync
  with isPlaying and the current instrument value.
- On localStorage restore, updateToggleButton() is called before
  startPitchDetect() so the "Start" button is visible immediately even
  if the browser blocks auto-start due to a missing user gesture.
- stopPitchDetect() no longer resets the instrument dropdown to index 0,
  so the user can click "Start" again without reselecting the instrument.
- The correct clef is preserved on the staff after stopping.

https://claude.ai/code/session_014JmkjkkqkT78BX8AwYpfkp