### PR TITLE
Fix saxophone fingering image offset (minor 3rd correction)

### DIFF
--- a/js/fingerings.js
+++ b/js/fingerings.js
@@ -236,9 +236,12 @@ var imageFingeringMap = {
 	"clarinet":  { folder: "Clarinet",  ext: "png", transposition: 0  },
 	"flute":     { folder: "Flute",     ext: "png", transposition: 0  },
 	"oboe":      { folder: "Oboe",      ext: "png", transposition: 0  },
-	"alto sax":  { folder: "Saxophone", ext: "png", transposition: 9  },
-	"tenor sax": { folder: "Saxophone", ext: "png", transposition: 14 },
-	"bari sax":  { folder: "Saxophone", ext: "png", transposition: 21 },
+	// All saxophones share the same fingering images indexed at writtenMidi - 12.
+	// (The image set uses a MIDI numbering where C4 = 48 instead of 60,
+	//  so we subtract 12 regardless of which saxophone is selected.)
+	"alto sax":  { folder: "Saxophone", ext: "png", transposition: 12 },
+	"tenor sax": { folder: "Saxophone", ext: "png", transposition: 12 },
+	"bari sax":  { folder: "Saxophone", ext: "png", transposition: 12 },
 	"trombone":  { folder: "Trombone",  ext: "gif", transposition: 0  }
 };
 


### PR DESCRIPTION
The saxophone images are indexed using writtenMidi - 12 (the image set uses a MIDI numbering convention where C4 = 48 rather than 60). The previous transpositions (9/14/21 per sax type) were off by a minor 3rd.

All three saxophones now use transposition: 12, which is correct because all saxes share the same physical fingering for any given written note — the images map 1:1 to written pitch regardless of which sax is selected.

https://claude.ai/code/session_01Qb1AXT9waUECZdUN94iPAL