### PR TITLE
Add 'Listen to me' feature to note trainer



### DIFF
--- a/note-trainer.html
+++ b/note-trainer.html
@@ -201,6 +201,37 @@
 				background-color: #a93226;
 			}
 
+			#listenButton {
+				padding: 12px 32px;
+				font-size: 16px;
+				font-family: 'Alike', sans-serif;
+				background-color: #2196F3;
+				color: white;
+				border: none;
+				border-radius: 6px;
+				cursor: pointer;
+				transition: background-color 0.2s;
+				display: none;
+			}
+
+			#listenButton:hover {
+				background-color: #1976D2;
+			}
+
+			#listenButton.listening {
+				background-color: #e74c3c;
+				animation: pulse 1.5s ease-in-out infinite;
+			}
+
+			#listenButton.listening:hover {
+				background-color: #c0392b;
+			}
+
+			@keyframes pulse {
+				0%, 100% { opacity: 1; }
+				50% { opacity: 0.75; }
+			}
+
 			.main-display {
 				flex: 1;
 				display: flex;
@@ -383,6 +414,7 @@
 
 				#instrument,
 				#playButton,
+				#listenButton,
 				#clearButton {
 					width: 100%;
 					max-width: 280px;
@@ -470,6 +502,7 @@
 					<option value="glockenspiel">Glockenspiel</option>
 				</select>
 			<button id="playButton" onclick="handlePlayButton()">Play Sound</button>
+				<button id="listenButton" onclick="handleListenButton()">Listen to me</button>
 				<button id="clearButton" onclick="clearNote()">Clear</button>
 				<label id="sustainSwitch" class="sustain-switch" title="Hold note until stopped">
 				<input type="checkbox" id="sustainToggle" onchange="onSustainChange()">


### PR DESCRIPTION
Adds a microphone pitch detection mode to the note trainer page.
When a note is placed on the staff, a blue "Listen to me" button
appears alongside the Play button. Clicking it opens the mic and
uses the same MPM autocorrelation pitch detector as the main pitch
detector page to listen to what the user plays.

The detected pitch appears as a gray ghost half note to the right of
the placed (black) half note on the staff, updating in real time as
the user plays. The two notes are rendered side by side using two
VexFlow voices, making it easy to see the target pitch vs. what is
actually being played. The detected note disappears when no clear
pitch is heard.

The listening session stops automatically when the user:
- Clicks a different note on the staff
- Uses the ▲/▼ pitch buttons
- Uses arrow keys to navigate to a different note
- Clicks the "Stop Listening" button (same button, toggled)
- Clicks Clear

Transposition is respected: for transposing instruments the detected
concert pitch is converted to written pitch before display.

https://claude.ai/code/session_01MVTFchDQ3VksfmSekXsu25