### PR TITLE
Move listen button above staff, center staff vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,12 +269,28 @@
 				margin-top: 10px;
 			}
 
+			.staff-column {
+				flex: 1;
+				display: flex;
+				flex-direction: column;
+				gap: 10px;
+				min-width: 0;
+				min-height: 0;
+			}
+
+			.staff-listen-row {
+				display: flex;
+				justify-content: center;
+				flex-shrink: 0;
+			}
+
 			.staff-wrapper {
 				flex: 1;
 				display: flex;
 				gap: 10px;
 				align-items: stretch;
 				min-width: 0;
+				min-height: 0;
 			}
 
 			.staff-container {
@@ -406,14 +422,14 @@
 
 				#instrument,
 				#playButton,
-				#listenButton,
 				#clearButton {
 					width: 100%;
 					max-width: 280px;
 				}
 
 				#listenButton {
-					order: 1;
+					width: 100%;
+					max-width: 280px;
 				}
 
 				.main-display {
@@ -423,6 +439,11 @@
 				#note-display {
 					flex: none;
 					min-height: 150px;
+				}
+
+				.staff-column {
+					flex: 1;
+					min-height: 220px;
 				}
 
 				.staff-wrapper {
@@ -494,7 +515,6 @@
 					<option value="glockenspiel">Glockenspiel</option>
 				</select>
 			<button id="playButton" onclick="handlePlayButton()">Play Sound</button>
-				<button id="listenButton" onclick="handleListenButton()">Listen to me</button>
 				<button id="clearButton" onclick="clearNote()">Clear</button>
 				<label id="sustainSwitch" class="sustain-switch" title="Hold note until stopped">
 				<input type="checkbox" id="sustainToggle" onchange="onSustainChange()">
@@ -509,14 +529,19 @@
 					<div id="frequency-display"></div>
 				</div>
 
-				<div class="staff-wrapper">
-					<div class="staff-container" id="staff-container">
-						<div id="staff-instruction">Click on the staff to place a note</div>
-						<div id="staff-output"></div>
+				<div class="staff-column">
+					<div class="staff-listen-row">
+						<button id="listenButton" onclick="handleListenButton()">Listen to me</button>
 					</div>
-					<div class="pitch-controls">
-						<button id="pitchUpButton" class="pitch-button" onclick="adjustPitch(1)" title="Raise pitch by half step">&#9650;</button>
-						<button id="pitchDownButton" class="pitch-button" onclick="adjustPitch(-1)" title="Lower pitch by half step">&#9660;</button>
+					<div class="staff-wrapper">
+						<div class="staff-container" id="staff-container">
+							<div id="staff-instruction">Click on the staff to place a note</div>
+							<div id="staff-output"></div>
+						</div>
+						<div class="pitch-controls">
+							<button id="pitchUpButton" class="pitch-button" onclick="adjustPitch(1)" title="Raise pitch by half step">&#9650;</button>
+							<button id="pitchDownButton" class="pitch-button" onclick="adjustPitch(-1)" title="Lower pitch by half step">&#9660;</button>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/js/notetrainer.js
+++ b/js/notetrainer.js
@@ -44,7 +44,7 @@ var fireworksParticles = [];
 var STAFF_WIDTH = 280;
 var STAFF_HEIGHT = 140;
 var STAFF_X = 10;
-var STAFF_Y = 35;
+var STAFF_Y = 50;
 var LINE_SPACING = 10;  // Space between staff lines in internal coordinates
 
 // Dynamic staff layout values (updated by drawStaff from VexFlow)


### PR DESCRIPTION
- Removed listenButton from .controls row; placed it in a new
  .staff-listen-row div directly above the staff-wrapper
- Wrapped staff-wrapper in a .staff-column flex column so the
  button sits flush above the staff box
- Changed STAFF_Y from 35 to 50 so the five staff lines are
  vertically centered in the 140px SVG viewBox (line center = 70)

https://claude.ai/code/session_01LVUVkaGvNMVYMigdPHoGeQ