### PR TITLE
Keep "Listen to me" active when note changes on staff

### DIFF
--- a/js/notetrainer.js
+++ b/js/notetrainer.js
@@ -691,11 +691,6 @@ function handleStaffClick(event) {
 	ghostNote = null;
 	ghostOctave = null;
 
-	// Stop listening if active — user placed a new note
-	if (listenActive) {
-		stopListening();
-	}
-
 	// Update display
 	updateNoteDisplay();
 	document.getElementById("note-name").style.opacity = "1";
@@ -750,11 +745,6 @@ function handleKeyDown(event) {
 		var concertMidi = currentMidi - transposition;
 		currentFrequency = frequencyFromNoteNumber(concertMidi);
 
-		// Stop listening if active — note changed via arrow key
-		if (listenActive) {
-			stopListening();
-		}
-
 		// Update display and redraw staff
 		updateNoteDisplay();
 		drawStaff(currentNote, currentOctave, null, null);
@@ -808,11 +798,6 @@ function adjustPitch(semitones) {
 		var transposition = getTransposition();
 		var concertMidi = currentMidi - transposition;
 		currentFrequency = frequencyFromNoteNumber(concertMidi);
-
-		// Stop listening if active — note changed via pitch button
-		if (listenActive) {
-			stopListening();
-		}
 
 		// Update display and redraw staff
 		updateNoteDisplay();


### PR DESCRIPTION
Previously, placing a new note, using arrow keys, or clicking pitch buttons would automatically stop the microphone listening session. Now listening persists until the user explicitly clicks "Stop Listening" or clears the note entirely.

https://claude.ai/code/session_01Vgfna27jecViLf7LfE3LHR