### PR TITLE
Improve onboarding, toolbar grouping, and note display clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,13 @@
 				border-color: var(--accent);
 			}
 
+			/* Until an instrument is chosen it is the only usable control, so
+			   give it an accent treatment that points the first-time user at it. */
+			#instrument.attention {
+				border-color: var(--accent);
+				box-shadow: 0 0 0 3px var(--accent-ring);
+			}
+
 			#instrument:focus-visible {
 				outline: none;
 				border-color: var(--accent);
@@ -235,10 +242,26 @@
 
 			/* Secondary outline: Listen */
 			#listenButton {
-				padding: 11px 28px;
+				padding: 11px 24px;
 				background-color: var(--surface);
 				color: var(--accent);
 				border: 1px solid var(--border-strong);
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				gap: 8px;
+			}
+
+			#listenButton svg {
+				flex-shrink: 0;
+			}
+
+			/* Separates note playback controls from the mic control */
+			.controls-divider {
+				width: 1px;
+				height: 26px;
+				background: var(--border-strong);
+				flex-shrink: 0;
 			}
 
 			#listenButton:hover {
@@ -396,7 +419,7 @@
 
 			#note-name {
 				/* clamp() sets the ceiling; fitNoteName() in JS shrinks from here
-				   so a longer label (e.g. "C♯ / D♭") stays on one line instead of
+				   so a longer label (e.g. "C♯4 / D♭4") stays on one line instead of
 				   wrapping and growing the box. */
 				font-size: clamp(60px, 15vw, 140px);
 				line-height: 1.05;
@@ -409,12 +432,101 @@
 				transition: opacity 0.15s;
 			}
 
+			/* Octave number rendered smaller than the note letter */
+			.note-octave {
+				font-size: 0.45em;
+				font-weight: 600;
+				color: var(--text-muted);
+			}
+
 			#frequency-display {
 				font-size: 0.95rem;
 				font-variant-numeric: tabular-nums;
 				color: var(--text-muted);
 				margin-top: 8px;
 				min-height: 1.2em;
+			}
+
+			/* ---------- Getting-started guide ---------- */
+			/* Fills the note panel until any note (placed, ghost, or detected)
+			   exists; the note readouts take over from there. */
+			.getting-started {
+				display: none;
+				text-align: left;
+			}
+
+			#note-display.show-guide #note-name,
+			#note-display.show-guide #frequency-display,
+			#note-display.show-guide #concert-pitch-display {
+				display: none;
+			}
+
+			#note-display.show-guide .getting-started {
+				display: block;
+			}
+
+			.gs-title {
+				text-align: center;
+				font-size: 0.78rem;
+				font-weight: 600;
+				letter-spacing: 0.06em;
+				text-transform: uppercase;
+				color: var(--text-muted);
+				margin-bottom: 18px;
+			}
+
+			.getting-started ol {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+				display: flex;
+				flex-direction: column;
+				gap: 16px;
+			}
+
+			.getting-started li {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+				color: var(--text-muted);
+				font-size: 0.95rem;
+				transition: color 0.2s;
+			}
+
+			.gs-num {
+				width: 28px;
+				height: 28px;
+				border-radius: 50%;
+				border: 1.5px solid var(--border-strong);
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				font-weight: 600;
+				font-size: 0.85rem;
+				color: var(--text-muted);
+				flex-shrink: 0;
+				transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+			}
+
+			.getting-started li.current {
+				color: var(--text);
+				font-weight: 500;
+			}
+
+			.getting-started li.current .gs-num {
+				background-color: var(--accent);
+				border-color: var(--accent);
+				color: #fff;
+			}
+
+			.getting-started li.done {
+				color: var(--text-faint);
+			}
+
+			.getting-started li.done .gs-num {
+				background-color: var(--success-soft);
+				border-color: var(--success);
+				color: var(--success);
 			}
 
 			#concert-pitch-display {
@@ -449,12 +561,6 @@
 				min-width: 0;
 				min-height: 0;
 				transition: flex-grow 0.25s ease;
-			}
-
-			.staff-listen-row {
-				display: flex;
-				justify-content: center;
-				flex-shrink: 0;
 			}
 
 			/* ---------- Key signature popup ---------- */
@@ -970,6 +1076,13 @@
 					max-width: 280px;
 				}
 
+				/* Stacked toolbar: the divider becomes a horizontal hairline */
+				.controls-divider {
+					width: 100%;
+					max-width: 280px;
+					height: 1px;
+				}
+
 				.main-display {
 					flex-direction: column;
 				}
@@ -1047,22 +1160,30 @@
 			<div class="controls">
 				<select name="Instrument" id="instrument">
 					<option value="">Select an instrument</option>
-					<option value="treble clef">Treble Clef</option>
-					<option value="bass clef">Bass Clef</option>
-					<option value="flute">Flute</option>
-					<option value="oboe">Oboe</option>
-					<option value="clarinet">Clarinet</option>
-					<option value="bass clarinet">Bass Clarinet</option>
-					<option value="bassoon">Bassoon</option>
-					<option value="alto sax">Alto Sax</option>
-					<option value="tenor sax">Tenor Sax</option>
-					<option value="bari sax">Bari Sax</option>
-					<option value="trumpet">Trumpet</option>
-					<option value="horn">Horn</option>
-					<option value="trombone">Trombone</option>
-					<option value="euphonium">Euphonium</option>
-					<option value="tuba">Tuba</option>
-					<option value="glockenspiel">Glockenspiel</option>
+					<optgroup label="Clefs">
+						<option value="treble clef">Treble Clef</option>
+						<option value="bass clef">Bass Clef</option>
+					</optgroup>
+					<optgroup label="Woodwinds">
+						<option value="flute">Flute</option>
+						<option value="oboe">Oboe</option>
+						<option value="clarinet">Clarinet</option>
+						<option value="bass clarinet">Bass Clarinet</option>
+						<option value="bassoon">Bassoon</option>
+						<option value="alto sax">Alto Sax</option>
+						<option value="tenor sax">Tenor Sax</option>
+						<option value="bari sax">Bari Sax</option>
+					</optgroup>
+					<optgroup label="Brass">
+						<option value="trumpet">Trumpet</option>
+						<option value="horn">Horn</option>
+						<option value="trombone">Trombone</option>
+						<option value="euphonium">Euphonium</option>
+						<option value="tuba">Tuba</option>
+					</optgroup>
+					<optgroup label="Percussion">
+						<option value="glockenspiel">Glockenspiel</option>
+					</optgroup>
 				</select>
 				<button id="playButton" onclick="handlePlayButton()">Play Sound</button>
 				<button id="clearButton" onclick="clearNote()">Clear</button>
@@ -1071,6 +1192,11 @@
 					<span class="sustain-slider"></span>
 					<span>Sustain</span>
 				</label>
+				<div class="controls-divider"></div>
+				<button id="listenButton" onclick="handleListenButton()">
+					<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="22"/></svg>
+					<span id="listenLabel">Listen to me</span>
+				</button>
 			</div>
 
 			<div class="main-display">
@@ -1078,12 +1204,17 @@
 					<span id="note-name">-</span>
 					<div id="frequency-display"></div>
 					<div id="concert-pitch-display"></div>
+					<div id="getting-started" class="getting-started">
+						<div class="gs-title">How it works</div>
+						<ol>
+							<li id="gs-step-1"><span class="gs-num">1</span><span>Choose your instrument</span></li>
+							<li id="gs-step-2"><span class="gs-num">2</span><span id="gs-step-2-label">Click a note on the staff</span></li>
+							<li id="gs-step-3"><span class="gs-num">3</span><span>Play it back, or press Listen and play it yourself</span></li>
+						</ol>
+					</div>
 				</div>
 
 				<div class="staff-column">
-					<div class="staff-listen-row">
-						<button id="listenButton" onclick="handleListenButton()">Listen to me</button>
-					</div>
 					<div class="staff-wrapper">
 						<div class="staff-panel">
 							<div class="staff-label">Target Note</div>

--- a/js/notetrainer.js
+++ b/js/notetrainer.js
@@ -783,16 +783,11 @@ function handleStaffMouseMove(event) {
 
 		// Update display with ghost note info
 		var noteNameElem = document.getElementById("note-name");
-		// Show enharmonic equivalent if it exists
-		var enharmonic = enharmonicMap[ghostNote];
-		if (enharmonic) {
-			noteNameElem.textContent = ghostNote + " / " + enharmonic;
-		} else {
-			noteNameElem.textContent = ghostNote;
-		}
+		noteNameElem.innerHTML = writtenNoteHTML(ghostNote, ghostOctave);
 		noteNameElem.style.opacity = "0.5";
 		updateConcertPitchDisplay(ghostMidi);
 		updatePianoDisplay(ghostMidi);
+		updateGettingStarted();
 	}
 }
 
@@ -818,6 +813,7 @@ function handleStaffMouseLeave(event) {
 	noteNameElem.style.opacity = "1";
 	updateConcertPitchDisplay(null);
 	updatePianoDisplay(null);
+	updateGettingStarted();
 }
 
 // Handle click on staff
@@ -1008,43 +1004,63 @@ function updatePianoDisplay(writtenMidi) {
 	drawPianoKeyboard(concertPc, keyDisplayName(concertNoteName));
 }
 
-// Show concert pitch note name below the note box when the instrument transposes
+// Build the big note label as HTML: note letters with real sharp/flat glyphs
+// and a smaller octave number, e.g. A4 or C(sharp)4 / D(flat)4 for enharmonics
+function writtenNoteHTML(noteName, octave) {
+	var html = keyDisplayName(noteName) + '<span class="note-octave">' + octave + '</span>';
+	if (enharmonicMap[noteName]) {
+		html += ' / ' + keyDisplayName(enharmonicMap[noteName]) + '<span class="note-octave">' + octave + '</span>';
+	}
+	return html;
+}
+
+// Update the two lines under the big note name. The first shows the sounding
+// concert pitch (with octave) and its frequency; the second labels the big
+// note as written pitch when the instrument transposes, so written vs concert
+// is never ambiguous.
 function updateConcertPitchDisplay(writtenMidi) {
-	var elem = document.getElementById("concert-pitch-display");
-	if (!elem) return;
-	var transposition = getTransposition();
-	if (transposition === 0 || writtenMidi === null || writtenMidi === undefined) {
-		elem.textContent = "";
+	var freqElem = document.getElementById("frequency-display");
+	var writtenElem = document.getElementById("concert-pitch-display");
+	if (!freqElem || !writtenElem) return;
+
+	if (writtenMidi === null || writtenMidi === undefined) {
+		freqElem.textContent = "";
+		writtenElem.textContent = "";
 		return;
 	}
+
+	var transposition = getTransposition();
 	var concertMidi = writtenMidi - transposition;
 	var concertPc = ((concertMidi % 12) + 12) % 12;
+	var concertOctave = Math.floor(concertMidi / 12) - 1;
 	var concertNoteName = spellNoteForKey(concertPc, concertKey);
-	elem.textContent = "Concert " + keyDisplayName(concertNoteName);
+	var freq = frequencyFromNoteNumber(concertMidi);
+	freqElem.textContent = "Concert " + keyDisplayName(concertNoteName) + concertOctave +
+		" \u00b7 " + Math.round(freq) + " Hz";
+
+	if (transposition !== 0) {
+		var sel = document.getElementById("instrument");
+		var label = sel.selectedIndex >= 0 ? sel.options[sel.selectedIndex].text : "";
+		writtenElem.textContent = "as written for " + label;
+	} else {
+		writtenElem.textContent = "";
+	}
 }
 
 // Update the note name display
 function updateNoteDisplay() {
 	var noteNameElem = document.getElementById("note-name");
-	var freqElem = document.getElementById("frequency-display");
 
 	if (currentNote && currentOctave !== null) {
-		// Check for enharmonic equivalent
-		var displayName = currentNote;
-		if (enharmonicMap[currentNote]) {
-			displayName = currentNote + " / " + enharmonicMap[currentNote];
-		}
-
-		noteNameElem.textContent = displayName;
-		freqElem.textContent = Math.round(currentFrequency) + " Hz (concert pitch)";
+		noteNameElem.innerHTML = writtenNoteHTML(currentNote, currentOctave);
 		updateConcertPitchDisplay(currentMidi);
 		updatePianoDisplay(currentMidi);
 	} else {
 		noteNameElem.textContent = "-";
-		freqElem.textContent = "";
 		updateConcertPitchDisplay(null);
 		updatePianoDisplay(null);
 	}
+	updateGettingStarted();
 }
 
 // Shrink the note-name text so longer labels (sharps/flats shown with their
@@ -1091,6 +1107,29 @@ function updateControlStates() {
 	var sustainToggle = document.getElementById("sustainToggle");
 	sustainSwitch.classList.toggle("is-disabled", !hasNote);
 	sustainToggle.disabled = !hasNote;
+
+	// Point the first-time user at the one control that does something
+	document.getElementById("instrument").classList.toggle("attention", !instrumentSelected);
+	updateGettingStarted();
+}
+
+// Show the "How it works" steps in the note panel until any note exists
+// (placed, hovered ghost, or mic-detected), and keep step progress current.
+function updateGettingStarted() {
+	var display = document.getElementById("note-display");
+	var step1 = document.getElementById("gs-step-1");
+	var step2 = document.getElementById("gs-step-2");
+	if (!display || !step1 || !step2) return;
+
+	var hasAnyNote = currentNote !== null || ghostNote !== null || detectedMidi !== null;
+	display.classList.toggle("show-guide", !hasAnyNote);
+	if (hasAnyNote) return;
+
+	var instrumentSelected = !!document.getElementById("instrument").value;
+	step1.classList.toggle("done", instrumentSelected);
+	step1.classList.toggle("current", !instrumentSelected);
+	step1.querySelector(".gs-num").textContent = instrumentSelected ? "\u2713" : "1";
+	step2.classList.toggle("current", instrumentSelected);
 }
 
 // Adjust pitch by semitones (for mobile pitch control buttons)
@@ -1784,12 +1823,12 @@ function commitDetectedNote(writtenMidi) {
 	} else {
 		drawStaff(detectedNote, detectedOctave, null, null, null);
 		var noteNameElem = document.getElementById("note-name");
-		var enharmonic = enharmonicMap[detectedNote];
-		noteNameElem.textContent = enharmonic ? detectedNote + " / " + enharmonic : detectedNote;
+		noteNameElem.innerHTML = writtenNoteHTML(detectedNote, detectedOctave);
 		noteNameElem.style.opacity = "1";
 		updateConcertPitchDisplay(detectedMidi);
 		updatePianoDisplay(detectedMidi);
 	}
+	updateGettingStarted();
 }
 
 // Clear the detected note from the staff and note displays
@@ -1806,6 +1845,7 @@ function clearDetectedNote() {
 		updateConcertPitchDisplay(null);
 		updatePianoDisplay(null);
 	}
+	updateGettingStarted();
 }
 
 // Update the tuner meter with a cents offset (-50..+50 shown), or null when
@@ -1939,7 +1979,7 @@ function startListening() {
 		}
 
 		var listenButton = document.getElementById("listenButton");
-		listenButton.textContent = "Stop Listening";
+		document.getElementById("listenLabel").textContent = "Stop Listening";
 		listenButton.classList.add("listening");
 	}).catch(function(err) {
 		console.error("Microphone access error:", err);
@@ -2000,9 +2040,11 @@ function stopListening() {
 
 	var listenButton = document.getElementById("listenButton");
 	if (listenButton) {
-		listenButton.textContent = "Listen to me";
+		document.getElementById("listenLabel").textContent = "Listen to me";
 		listenButton.classList.remove("listening");
 	}
+
+	updateGettingStarted();
 }
 
 // Format a key name for display, replacing b/# with ♭/♯
@@ -2284,6 +2326,14 @@ document.addEventListener("DOMContentLoaded", function() {
 
 	// Set up keyboard handler for arrow key navigation
 	document.addEventListener("keydown", handleKeyDown);
+
+	// "Click" reads wrong on touch devices — swap the instructional wording
+	if (window.matchMedia && window.matchMedia("(pointer: coarse)").matches) {
+		var stepLabel = document.getElementById("gs-step-2-label");
+		if (stepLabel) stepLabel.textContent = "Tap a note on the staff";
+		var instructionEl = document.getElementById("staff-instruction");
+		if (instructionEl) instructionEl.textContent = "Tap the staff to place a note";
+	}
 
 	// The staff SVG self-scales on resize; realign the key-signature hotspot
 	window.addEventListener("resize", positionKeySigHotspot);


### PR DESCRIPTION
Four UI improvements:

- Getting-started guide: the note panel shows numbered "How it works" steps until any note exists (placed, hovered, or detected), with step progress marked as the user advances. The instrument select gets an accent ring until one is chosen, and instructional text says "Tap" instead of "Click" on touch devices.
- Toolbar grouping: the Listen button moves from above the staff into the main toolbar with a mic icon, separated from the playback controls by a divider, so all controls live in one place.
- Instrument optgroups: the dropdown is grouped into Clefs, Woodwinds, Brass, and Percussion.
- Note display clarity: the big note name now includes the octave (smaller, muted) and uses real sharp/flat glyphs (A♯4 / B♭4). The sublines read "Concert G4 · 392 Hz" and "as written for Trumpet", making written vs concert pitch unambiguous for transposing instruments.


Claude-Session: https://claude.ai/code/session_01C9VuzqiXyPH7CZbwc8TidJ